### PR TITLE
Added more titles.

### DIFF
--- a/mmap/000400000012BE00.xml
+++ b/mmap/000400000012BE00.xml
@@ -1,0 +1,27 @@
+<!-- Harvest Moon The Lost Valley (EUR) -->
+<header>
+	<data_address>0x36A000</data_address>
+	<processAppCodeAddress>0x105000</processAppCodeAddress>
+	<num>0x3</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0x200000</processLinearOffset>
+	<processHookAddress>0x1021A0</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0x1f8000</size>
+	</entry>
+	<entry>
+		<src>0x2f8000</src>
+		<dst>-0x70000</dst>
+		<size>0x70000</size>
+	</entry>
+	<entry>
+		<src>0x368000</src>
+		<dst>-0x72000</dst>
+		<size>0x2000</size>
+	</entry>
+</map>

--- a/mmap/0004000000160200.xml
+++ b/mmap/0004000000160200.xml
@@ -1,0 +1,27 @@
+<!-- Goosebumps The Game (USA) -->
+<header>
+	<data_address>0x3D9000</data_address>
+	<processAppCodeAddress>0x105000</processAppCodeAddress>
+	<num>0x3</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0x200000</processLinearOffset>
+	<processHookAddress>0x3734E0</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0x1f8000</size>
+	</entry>
+	<entry>
+		<src>0x2f8000</src>
+		<dst>-0xe0000</dst>
+		<size>0xe0000</size>
+	</entry>
+	<entry>
+		<src>0x3d8000</src>
+		<dst>-0xe1000</dst>
+		<size>0x1000</size>
+	</entry>
+</map>

--- a/mmap/0004000000169600.xml
+++ b/mmap/0004000000169600.xml
@@ -1,0 +1,27 @@
+<!-- Dragon Ball Z: Extreme Butoden (EUR) -->
+<header>
+	<data_address>0x3B9000</data_address>
+	<processAppCodeAddress>0x105000</processAppCodeAddress>
+	<num>0x3</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0x200000</processLinearOffset>
+	<processHookAddress>0x104B60</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0x1f8000</size>
+	</entry>
+	<entry>
+		<src>0x2f8000</src>
+		<dst>-0xc0000</dst>
+		<size>0xc0000</size>
+	</entry>
+	<entry>
+		<src>0x3b8000</src>
+		<dst>-0xc1000</dst>
+		<size>0x1000</size>
+	</entry>
+</map>

--- a/mmap/0004000000169800.xml
+++ b/mmap/0004000000169800.xml
@@ -1,0 +1,22 @@
+<!-- Garfield Kart (USA) -->
+<header>
+	<data_address>0x1BA000</data_address>
+	<processAppCodeAddress>0x105000</processAppCodeAddress>
+	<num>0x2</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0xC0000</processLinearOffset>
+	<processHookAddress>0x100E20</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0xb8000</size>
+	</entry>
+	<entry>
+		<src>0x1b8000</src>
+		<dst>-0x2000</dst>
+		<size>0x2000</size>
+	</entry>
+</map>

--- a/mmap/0004000000169900.xml
+++ b/mmap/0004000000169900.xml
@@ -1,0 +1,27 @@
+<!-- The Peanuts Movie: Snoopy's Grand Adventure (USA) -->
+<header>
+	<data_address>0x851000</data_address>
+	<processAppCodeAddress>0x10B000</processAppCodeAddress>
+	<num>0x3</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0x700000</processLinearOffset>
+	<processHookAddress>0x105E00</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0x6f8000</size>
+	</entry>
+	<entry>
+		<src>0x7f8000</src>
+		<dst>-0x50000</dst>
+		<size>0x50000</size>
+	</entry>
+	<entry>
+		<src>0x848000</src>
+		<dst>-0x59000</dst>
+		<size>0x9000</size>
+	</entry>
+</map>

--- a/mmap/000400000016B900.xml
+++ b/mmap/000400000016B900.xml
@@ -1,0 +1,22 @@
+<!-- Paddington: Adventures in London (USA) -->
+<header>
+	<data_address>0x303000</data_address>
+	<processAppCodeAddress>0x105000</processAppCodeAddress>
+	<num>0x2</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0x200000</processLinearOffset>
+	<processHookAddress>0x102F20</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0x1f8000</size>
+	</entry>
+	<entry>
+		<src>0x2f8000</src>
+		<dst>-0xb000</dst>
+		<size>0xb000</size>
+	</entry>
+</map>

--- a/mmap/000400000016CD00.xml
+++ b/mmap/000400000016CD00.xml
@@ -1,0 +1,27 @@
+<!-- Dragon Ball Z: Extreme Butoden (USA) -->
+<header>
+	<data_address>0x3B9000</data_address>
+	<processAppCodeAddress>0x105000</processAppCodeAddress>
+	<num>0x3</num>
+	<text_end>0x160000</text_end>
+	<processLinearOffset>0x200000</processLinearOffset>
+	<processHookAddress>0x104B60</processHookAddress>
+	<data_size>0x0</data_size>
+</header>
+<map>
+	<entry>
+		<src>0x100000</src>
+		<dst>0x8000</dst>
+		<size>0x1f8000</size>
+	</entry>
+	<entry>
+		<src>0x2f8000</src>
+		<dst>-0xc0000</dst>
+		<size>0xc0000</size>
+	</entry>
+	<entry>
+		<src>0x3b8000</src>
+		<dst>-0xc1000</dst>
+		<size>0x1000</size>
+	</entry>
+</map>


### PR DESCRIPTION
000400000012BE00 = Harvest Moon The Lost Valley (EUR)
0004000000160200 = Goosebumps The Game (USA)
0004000000169600 = Dragon Ball Z: Extreme Butoden (EUR)
0004000000169800 = Garfield Kart (USA)
0004000000169900 = The Peanuts Movie: Snoopy's Grand Adventure (USA)
000400000016B900 = Paddington: Adventures in London (USA)
000400000016CD00 = Dragon Ball Z: Extreme Butoden (USA)

After an internal rage of non-functional tools due to decisions on build time, I was able to fix 3dstool from the "Segmentation fault". With, by the way, failed to decrypt all of the games exefs on the first commit, before the fix.
